### PR TITLE
Define `web.Application.on_startup()` handler

### DIFF
--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1042,6 +1042,21 @@ duplicated like one using :meth:`Application.copy`.
           async def on_prepare(request, response):
               pass
 
+   .. attribute:: on_startup
+
+      A :class:`~aiohttp.signals.Signal` that is fired on application start-up.
+
+      Subscribers may use the signal to run background tasks in the event
+      loop along with the application's request handler just after the
+      application start-up.
+
+      Signal handlers should have the following signature::
+
+          async def on_startup(app):
+              pass
+
+      .. seealso:: :ref:`aiohttp-web-background-tasks`.
+
    .. attribute:: on_shutdown
 
       A :class:`~aiohttp.signals.Signal` that is fired on application shutdown.
@@ -1076,7 +1091,6 @@ duplicated like one using :meth:`Application.copy`.
 
       .. seealso:: :ref:`aiohttp-web-graceful-shutdown` and :attr:`on_shutdown`.
 
-
    .. method:: make_handler(**kwargs)
 
       Creates HTTP protocol factory for handling requests.
@@ -1103,6 +1117,14 @@ duplicated like one using :meth:`Application.copy`.
          await loop.create_server(app.make_handler(
             secure_proxy_ssl_header='X-Forwarded-Proto'),
             '0.0.0.0', 8080)
+
+   .. coroutinemethod:: startup()
+
+      A :ref:`coroutine<coroutine>` that will be called along with the
+      application's request handler.
+
+      The purpose of the method is calling :attr:`on_startup` signal
+      handlers.
 
    .. coroutinemethod:: shutdown()
 

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -9,12 +9,14 @@ def test_run_app_http(loop, mocker):
     loop.call_later(0.02, loop.stop)
 
     app = web.Application(loop=loop)
+    mocker.spy(app, 'startup')
 
     web.run_app(app, print=lambda *args: None)
 
     assert loop.is_closed()
     loop.create_server.assert_called_with(mock.ANY, '0.0.0.0', 8080,
                                           ssl=None, backlog=128)
+    app.startup.assert_called_once_with()
 
 
 def test_run_app_https(loop, mocker):
@@ -22,6 +24,7 @@ def test_run_app_https(loop, mocker):
     loop.call_later(0.02, loop.stop)
 
     app = web.Application(loop=loop)
+    mocker.spy(app, 'startup')
 
     ssl_context = ssl.create_default_context()
 
@@ -30,6 +33,7 @@ def test_run_app_https(loop, mocker):
     assert loop.is_closed()
     loop.create_server.assert_called_with(mock.ANY, '0.0.0.0', 8443,
                                           ssl=ssl_context, backlog=128)
+    app.startup.assert_called_once_with()
 
 
 def test_run_app_nondefault_host_port(loop, unused_port, mocker):
@@ -40,12 +44,14 @@ def test_run_app_nondefault_host_port(loop, unused_port, mocker):
     loop.call_later(0.02, loop.stop)
 
     app = web.Application(loop=loop)
+    mocker.spy(app, 'startup')
 
     web.run_app(app, host=host, port=port, print=lambda *args: None)
 
     assert loop.is_closed()
     loop.create_server.assert_called_with(mock.ANY, host, port,
                                           ssl=None, backlog=128)
+    app.startup.assert_called_once_with()
 
 
 def test_run_app_custom_backlog(loop, mocker):
@@ -53,9 +59,11 @@ def test_run_app_custom_backlog(loop, mocker):
     loop.call_later(0.02, loop.stop)
 
     app = web.Application(loop=loop)
+    mocker.spy(app, 'startup')
 
     web.run_app(app, backlog=10, print=lambda *args: None)
 
     assert loop.is_closed()
     loop.create_server.assert_called_with(mock.ANY, '0.0.0.0', 8080,
                                           ssl=None, backlog=10)
+    app.startup.assert_called_once_with()


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->
## What do these changes do?

<!-- Please give a short brief about these changes. -->

According to discussion in [#1092](https://github.com/KeepSafe/aiohttp/issues/1092) next changes were made:
- Define `web.Application.on_startup()` signal handler.
  - Run `app.on_startup()` along with the request handler within an event
    loop in `web.run_app()` and in `worker.GunicornWebWorker()`.
## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#1092
## Checklist
- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
